### PR TITLE
Declare the overall language of a page in the html root tag instead of using the meta tag

### DIFF
--- a/api/frontend/main.php
+++ b/api/frontend/main.php
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="content-language" content="en" />
         <meta name="theme-color" content="#2d3943" />
 
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Play:400,700">

--- a/web/frontend/logview.php
+++ b/web/frontend/logview.php
@@ -38,11 +38,10 @@ if (!$log->exists()) {
     }
 }
 ?><!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta name="robots" content="noindex,nofollow">
         <meta charset="utf-8" />
-        <meta http-equiv="content-language" content="en" />
         <meta name="theme-color" content="#2d3943" />
 
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Play:400,700">

--- a/web/frontend/main.php
+++ b/web/frontend/main.php
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="content-language" content="en" />
         <meta name="theme-color" content="#2d3943" />
 
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Play:400,700">


### PR DESCRIPTION
This moves the declaration of the language to the top / root <html> tag and both pages become HTML5 compliant.
See https://www.w3.org/International/techniques/authoring-html.en?open=language&open=textprocessing#textprocessing for more details.