### PR TITLE
Update composer.lock file

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55b3d2b33cf09dc865ddca770a443391",
+    "content-hash": "918a1df53b958ca064690204b99a11bc",
     "packages": [
         {
             "name": "aternos/codex",
@@ -313,8 +313,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "php": ">=8.0",
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
When running `composer install` it will output:
```
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
```

This updates the composer.lock file to remove this warning.

I ran `composer update --lock` for this.

