### PR TITLE
Install composer 2 from getcomposer.org

### DIFF
--- a/vagrant/setup-composer.sh
+++ b/vagrant/setup-composer.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+
+sudo mv composer.phar /usr/bin/composer
+
+exit $RESULT

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -9,7 +9,9 @@ sudo apt-get upgrade -y
 sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get update
 
-sudo apt-get install php8.0-fpm php8.0-mongodb php8.0-xml php8.0-redis nginx mongodb composer redis-server -y
+sudo apt-get install php8.0-fpm php8.0-mongodb php8.0-xml php8.0-redis nginx mongodb redis-server -y
+
+bash /web/mclogs/vagrant/setup-composer.sh
 
 cp /web/mclogs/vagrant/nginx/* /etc/nginx/sites-enabled/
 sudo service nginx restart


### PR DESCRIPTION
This installs composer v2.3.3 from getcomposer.org instead of using v1.1 from the apt-get repository.
The steps in setup-composer.sh follow the tutorial at https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md 