### PR TITLE
Fix permissions issue by removing owner and group properties from Vagrantfile

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "../", "/web/mclogs", owner: "www-data", group: "www-data"
+  config.vm.synced_folder "../", "/web/mclogs"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
When starting the vagrant vm using `vagrant up` and installing the composer packages afterwards by using `vagrant ssh`, `cd /web/mclogs/` and `composer install` I receive a permission denied error.
That is because I am the default vagrant user inside my vm but the mounted directory is owned by `www-data:www-data`.

This pr fixes this.