### PR TITLE
Allow adding entire log files using drag and drop

### DIFF
--- a/web/frontend/main.php
+++ b/web/frontend/main.php
@@ -73,7 +73,7 @@
                             <i class="fa fa-save"></i> Save
                         </div>
                     </div>
-                    <div class="paste-body">
+                    <div id="dropzone" class="paste-body">
                         <textarea id="paste" autocomplete="off" spellcheck="false"></textarea>
                     </div>
                     <div class="paste-footer">

--- a/web/frontend/main.php
+++ b/web/frontend/main.php
@@ -69,6 +69,9 @@
                         <div class="paste-header-text">
                             Paste your log here.
                         </div>
+                        <div id="paste-select-file" class="btn btn-orange btn-no-margin">
+                            <i class="fa fa-file-import"></i> Select
+                        </div>
                         <div class="paste-save btn btn-green btn-no-margin">
                             <i class="fa fa-save"></i> Save
                         </div>

--- a/web/public/css/mclogs.css
+++ b/web/public/css/mclogs.css
@@ -125,6 +125,17 @@ body {
 
 .paste-body {
     height: 600px;
+    outline-offset: -10px;
+    outline: transparent dashed 2px;
+    transition: outline-color .2s;
+}
+
+.paste-body.window-dragover {
+    outline-color: rgba(240, 240, 240, 0.5);
+}
+
+.paste-body.dragover {
+    outline-color: rgba(240, 240, 240, 1);
 }
 
 .info .row-inner {

--- a/web/public/css/mclogs.css
+++ b/web/public/css/mclogs.css
@@ -111,6 +111,10 @@ body {
     border-bottom: 3px solid #f0f0f0;
 }
 
+.paste-header .btn {
+    margin-left: 8px;
+}
+
 .paste-footer {
     background: #f0f0f0;
     padding: 6px 10px;

--- a/web/public/js/mclogs.js
+++ b/web/public/js/mclogs.js
@@ -107,11 +107,32 @@ async function handleDropEvent(e) {
     pasteArea.value = new TextDecoder().decode(content);
 }
 
+function loadScript(url) {
+    return new Promise((resolve, reject) => {
+        let elem = document.createElement('script');
+        elem.addEventListener('load', resolve);
+        elem.addEventListener('error', reject);
+        elem.src = url;
+        document.head.appendChild(elem);
+    });
+}
+
+async function loadFflate() {
+    if(typeof fflate === 'undefined') {
+        await loadScript('https://unpkg.com/fflate');
+    }
+}
+
 /**
  * @param {Uint8Array} data
  * @return {Promise<Uint8Array>}
  */
 async function unpackGz(data) {
+    if(typeof DecompressionStream === 'undefined') {
+        await loadFflate();
+        return fflate.gunzipSync(data);
+    }
+
     let inputStream = new ReadableStream({
         start: (controller) => {
             controller.enqueue(data);

--- a/web/public/js/mclogs.js
+++ b/web/public/js/mclogs.js
@@ -50,6 +50,7 @@ function sendLog() {
 }
 
 let dropZone = document.getElementById('dropzone');
+let fileSelectButton = document.getElementById('paste-select-file');
 let windowDragCount = 0;
 let dropZoneDragCount = 0;
 
@@ -90,8 +91,11 @@ async function handleDropEvent(e) {
     if (files.length !== 1) {
         return;
     }
-    let file = files[0];
 
+    await loadFileContents(files[0]);
+}
+
+async function loadFileContents(file) {
     if (file.size > 1024 * 1024 * 100) {
         return;
     }
@@ -121,6 +125,20 @@ async function loadFflate() {
     if(typeof fflate === 'undefined') {
         await loadScript('https://unpkg.com/fflate');
     }
+}
+
+function selectLogFile() {
+    let input = document.createElement('input');
+    input.type = 'file';
+    input.style.display = 'none';
+    document.body.appendChild(input);
+    input.onchange = async () => {
+        if(input.files.length) {
+            await loadFileContents(input.files[0]);
+        }
+    }
+    input.click();
+    document.body.removeChild(input);
 }
 
 /**
@@ -171,4 +189,6 @@ dropZone.addEventListener('drop', async e => {
     updateDropZoneDragCount(-1);
     await handleDropEvent(e);
 });
+
+fileSelectButton.addEventListener('click', selectLogFile);
 

--- a/web/public/js/mclogs.js
+++ b/web/public/js/mclogs.js
@@ -2,6 +2,7 @@ var titles = ["Paste", "Share", "Analyse"];
 var currentTitle = 0;
 var speed = 30;
 var pause = 3000;
+const pasteArea = document.getElementById('paste');
 
 setTimeout(nextTitle, pause);
 function nextTitle() {
@@ -27,7 +28,7 @@ function nextTitle() {
     setTimeout(nextTitle, title.length * speed + newTitle.length * speed + pause);
 }
 
-$('#paste').focus();
+$(pasteArea).focus();
 
 $('.paste-save').click(sendLog);
 $(document).keydown(function(event) {
@@ -38,7 +39,7 @@ $(document).keydown(function(event) {
 });
 
 function sendLog() {
-    if($('#paste').val() === "") {
+    if($(pasteArea).val() === "") {
         return false;
     }
 
@@ -47,3 +48,106 @@ function sendLog() {
         location.href = "/" + data.id;
     });
 }
+
+let dropZone = document.getElementById('dropzone');
+let windowDragCount = 0;
+let dropZoneDragCount = 0;
+
+function updateWindowDragCount(amount) {
+    windowDragCount = Math.max(0, windowDragCount + amount);
+    if (windowDragCount > 0) {
+        dropZone.classList.add('window-dragover');
+    } else {
+        dropZone.classList.remove('window-dragover');
+    }
+}
+
+function updateDropZoneDragCount(amount) {
+    dropZoneDragCount = Math.max(0, dropZoneDragCount + amount);
+    if (dropZoneDragCount > 0) {
+        dropZone.classList.add('dragover');
+    } else {
+        dropZone.classList.remove('dragover');
+    }
+}
+
+/**
+ * @param {Blob} file
+ * @return {Promise<Uint8Array>}
+ */
+function readFile(file) {
+    return new Promise((resolve, reject) => {
+        let reader = new FileReader();
+        // noinspection JSCheckFunctionSignatures
+        reader.onload = () => resolve(new Uint8Array(reader.result));
+        reader.onerror = e => reject(e);
+        reader.readAsArrayBuffer(file);
+    });
+}
+
+async function handleDropEvent(e) {
+    let files = e.dataTransfer.files;
+    if (files.length !== 1) {
+        return;
+    }
+    let file = files[0];
+
+    if (file.size > 1024 * 1024 * 100) {
+        return;
+    }
+    let content = await readFile(file);
+    if (file.name.endsWith('.gz')) {
+        content = await unpackGz(content);
+    }
+
+    if (content.includes(0)) {
+        return;
+    }
+
+    pasteArea.value = new TextDecoder().decode(content);
+}
+
+/**
+ * @param {Uint8Array} data
+ * @return {Promise<Uint8Array>}
+ */
+async function unpackGz(data) {
+    let inputStream = new ReadableStream({
+        start: (controller) => {
+            controller.enqueue(data);
+            controller.close();
+        }
+    });
+    const ds = new DecompressionStream('gzip');
+    const decompressedStream = inputStream.pipeThrough(ds);
+    return new Uint8Array(await new Response(decompressedStream).arrayBuffer());
+}
+
+window.addEventListener('dragover', e => e.preventDefault());
+window.addEventListener('dragenter', e => {
+    e.preventDefault();
+    updateWindowDragCount(1);
+});
+window.addEventListener('dragleave', e => {
+    e.preventDefault()
+    updateWindowDragCount(-1);
+});
+window.addEventListener('drop', e => {
+    e.preventDefault()
+    updateWindowDragCount(-1);
+});
+
+dropZone.addEventListener('dragenter', e => {
+    e.preventDefault();
+    updateDropZoneDragCount(1);
+});
+dropZone.addEventListener('dragleave', e => {
+    e.preventDefault();
+    updateDropZoneDragCount(-1);
+});
+dropZone.addEventListener('drop', async e => {
+    e.preventDefault();
+    updateDropZoneDragCount(-1);
+    await handleDropEvent(e);
+});
+


### PR DESCRIPTION
This change allows users to drag and drop an entire log file onto the page without having to open it and manually copy its contents. A button to select a local file using a traditional file select dialog is also added, since using drag and drop does is not possible on most mobile devices.
GZIP compressed log files (.gz) are unpacked automatically using the DecompressionStream API (if available) or fflate.

![Screenshot from 2022-08-29 15-05-48](https://user-images.githubusercontent.com/26512466/187208101-7979615d-3c04-4ff4-ac93-56fe5fe3da74.png)
![Screenshot from 2022-08-29 15-06-10](https://user-images.githubusercontent.com/26512466/187208154-0523c064-4205-4a30-9732-80c9258ca563.png)
(not sure about the look for the button yet)

