### PR TITLE
Add Raw button to log page

### DIFF
--- a/web/frontend/logview.php
+++ b/web/frontend/logview.php
@@ -119,8 +119,8 @@ if (!$log->exists()) {
                             <i class="fa fa-arrow-circle-down"></i>
                             <?=$lineNumbers . " " . $lineString; ?>
                         </div>
-                        <a class="btn btn-white btn-small btn-no-margin" id="raw" href="<?=$urls['apiBaseUrl'] . "/1/raw/". $id->get()?>">
-                            <i class="fa fa-font"></i>
+                        <a class="btn btn-white btn-small btn-no-margin" id="raw" target="_blank" href="<?=$urls['apiBaseUrl'] . "/1/raw/". $id->get()?>">
+                            <i class="fa fa-arrow-up-right-from-square"></i>
                             Raw
                         </a>
                     </div>

--- a/web/frontend/logview.php
+++ b/web/frontend/logview.php
@@ -119,6 +119,10 @@ if (!$log->exists()) {
                             <i class="fa fa-arrow-circle-down"></i>
                             <?=$lineNumbers . " " . $lineString; ?>
                         </div>
+                        <a class="btn btn-white btn-small btn-no-margin" id="raw" href="<?=$urls['apiBaseUrl'] . "/1/raw/". $id->get()?>">
+                            <i class="fa fa-font"></i>
+                            Raw
+                        </a>
                     </div>
                 </div>
                 <?php if(count($analysis) > 0): ?>


### PR DESCRIPTION
This PR adds a raw button to the top of the log page which redirects to the raw endpoint.
![Preview](https://github.com/aternosorg/mclogs/assets/45244473/ed367a22-5704-44e9-ac4d-a01105589dc1)

This can for example be used to quickly download or copy the log, or to view huge log files on mobile devices without lags while scrolling.