### PR TITLE
remove unnecessary padding around the notice

### DIFF
--- a/api/frontend/main.php
+++ b/api/frontend/main.php
@@ -17,7 +17,7 @@ $legal = Config::Get('legal');
 
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
         <link rel="stylesheet" href="css/btn.css" />
-        <link rel="stylesheet" href="css/mclogs.css?v=071223" />
+        <link rel="stylesheet" href="css/mclogs.css?v=071224" />
 
         <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
 

--- a/web/frontend/logview.php
+++ b/web/frontend/logview.php
@@ -186,6 +186,10 @@ if (!$log->exists()) {
                         <i class="fa fa-arrow-circle-up"></i>
                     </div>
                 </div>
+                <div class="log-notice">
+                    This log will be saved for 90 days from their last view.<br />
+                    <a href="mailto:<?=$legal['abuseEmail']?>?subject=Report%20mclo.gs/<?=$id->get(); ?>">Report abuse</a>
+                </div>
                 <?php else: ?>
                 <div class="not-found">
                     <div class="not-found-title">404 - Log not found.</div>
@@ -199,14 +203,6 @@ if (!$log->exists()) {
                 <?php endif; ?>
             </div>
         </div>
-        <?php if($log->exists()): ?>
-        <div class="row row-notice dark">
-            <div class="row-inner">
-                This log will be saved for 90 days from their last view.<br />
-                <a href="mailto:<?=$legal['abuseEmail']?>?subject=Report%20/<?=$urls['baseUrl'] . "/" . $id->get(); ?>">Report abuse</a>
-            </div>
-        </div>
-        <?php endif; ?>
         <div class="row footer">
             <div class="row-inner">
                 &copy; 2017-<?=date("Y"); ?> by mclo.gs - a service by <a target="_blank" href="https://aternos.org">Aternos</a> |

--- a/web/frontend/logview.php
+++ b/web/frontend/logview.php
@@ -49,7 +49,7 @@ if (!$log->exists()) {
         <link rel="stylesheet" href="vendor/fonts/fonts.css" />
         <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css" />
         <link rel="stylesheet" href="css/btn.css" />
-        <link rel="stylesheet" href="css/mclogs.css?v=071223" />
+        <link rel="stylesheet" href="css/mclogs.css?v=071224" />
         <link rel="stylesheet" href="css/log.css?v=071222" />
 
         <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />

--- a/web/frontend/main.php
+++ b/web/frontend/main.php
@@ -15,7 +15,7 @@ $legal = Config::Get('legal');
         <link rel="stylesheet" href="vendor/fonts/fonts.css" />
         <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css" />
         <link rel="stylesheet" href="css/btn.css" />
-        <link rel="stylesheet" href="css/mclogs.css?v=071223" />
+        <link rel="stylesheet" href="css/mclogs.css?v=071224" />
 
         <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
 

--- a/web/public/css/mclogs.css
+++ b/web/public/css/mclogs.css
@@ -274,12 +274,9 @@ body {
     flex-grow: 1;
 }
 
-.row-notice {
+.log-notice {
     font-size: 12px;
     text-align: center;
-}
-
-.row-notice .row-inner {
     color: #777;
 }
 


### PR DESCRIPTION
This PR removes the unnecessary padding between the log and the retention notice by moving the retention notice inside the same row.

Before:
![A lot of empty space](https://github.com/aternosorg/mclogs/assets/45244473/cd3dd8ec-d5cc-46fe-96ff-9007cf9ff787)

After:
![Less empty space](https://github.com/aternosorg/mclogs/assets/45244473/847e2d50-3ba6-4c5e-9379-1d22f742652c)
