### PR TITLE
Use smooth scrolling except for long distances

### DIFF
--- a/web/public/css/mclogs.css
+++ b/web/public/css/mclogs.css
@@ -9,6 +9,7 @@ html {
     height: 100%;
     overflow-x: hidden;
     -webkit-text-size-adjust: 100%;
+    scroll-behavior: smooth;
 }
 
 a {

--- a/web/public/js/logview.js
+++ b/web/public/js/logview.js
@@ -7,12 +7,24 @@ for (let line of document.querySelectorAll('.line-number')) {
 
 const downButton = document.getElementById("down-button");
 if (downButton) {
-    downButton.addEventListener("click", () => window.scrollTo(0, document.body.scrollHeight));
+    downButton.addEventListener("click", () => scrollToHeight(document.body.scrollHeight));
 }
 
 const upButton = document.getElementById("up-button");
 if (upButton) {
-    upButton.addEventListener("click", () => window.scrollTo(0, 0));
+    upButton.addEventListener("click", () => scrollToHeight(0));
+}
+
+/**
+ * Scroll to a specific height
+ * Disable smooth scrolling for large pages
+ * @param {number} top height to scroll to
+ * @param {number} [smoothScrollLimit] only use smooth scrolling if the distance is less than this value
+ */
+function scrollToHeight(top, smoothScrollLimit = 10000) {
+    const distance = Math.abs(document.documentElement.scrollTop - top);
+    const behavior = (distance < smoothScrollLimit) ? "smooth" : "instant";
+    window.scrollTo({left: 0, top, behavior});
 }
 
 function updateLineNumber(id) {

--- a/web/public/js/logview.js
+++ b/web/public/js/logview.js
@@ -91,7 +91,11 @@ if (toggleErrorsButton) {
                     document.getElementById(`L${i}`).parentElement.parentElement.hidden = false;
                 }
                 if (positionElement) {
-                    window.scrollTo(0, positionElement.getBoundingClientRect().top - position - collapsed.offsetHeight);
+                    window.scrollTo({
+                        left: 0,
+                        top: positionElement.getBoundingClientRect().top - position - collapsed.offsetHeight,
+                        behavior: "instant"
+                    });
                 }
                 collapsed.remove();
             })
@@ -120,7 +124,7 @@ if (wrapCheckbox) {
         } else {
             document.querySelector(".log-row .row-inner").classList.add("no-wrap");
         }
-        wrapCheckbox.scrollIntoView();
+        wrapCheckbox.scrollIntoView({behavior: "instant"});
         document.cookie = "WRAP_LOG_LINES=" + wrapCheckbox.checked + ";path=/";
     })
 }


### PR DESCRIPTION
As suggested in #91 this PR adds smooth scrolling to all buttons.
The buttons to jump to the end or beginning of the log will still scroll instantly when the height of the log exceeds 10,000px.