### PR TITLE
Limit log length and line count in frontend

### DIFF
--- a/web/frontend/main.php
+++ b/web/frontend/main.php
@@ -1,6 +1,7 @@
 <?php
 $urls = Config::Get('urls');
 $legal = Config::Get('legal');
+$storage = \Config::Get('storage');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -79,7 +80,7 @@ $legal = Config::Get('legal');
                         </div>
                     </div>
                     <div id="dropzone" class="paste-body">
-                        <textarea id="paste" autocomplete="off" spellcheck="false"></textarea>
+                        <textarea id="paste" autocomplete="off" spellcheck="false" data-max-length="<?=$storage['maxLength']?>" data-max-lines="<?=$storage['maxLines']?>"></textarea>
                     </div>
                     <div class="paste-footer">
                         <div class="paste-save btn btn-green btn-no-margin">
@@ -232,6 +233,6 @@ $legal = Config::Get('legal');
                 <a target="_blank" href="<?=$legal['privacy']?>>">Privacy</a>
             </div>
         </div>
-        <script src="js/mclogs.js?v=130221"></script>
+        <script src="js/mclogs.js?v=130222"></script>
     </body>
 </html>

--- a/web/public/js/mclogs.js
+++ b/web/public/js/mclogs.js
@@ -58,13 +58,17 @@ async function sendLog() {
     pasteSaveButtons.forEach(button => button.classList.add("btn-working"));
 
     try {
+        let log = pasteArea.value
+            .substring(0, parseInt(pasteArea.dataset.maxLength))
+            .split('\n').slice(0, parseInt(pasteArea.dataset.maxLines)).join('\n');
+
         const response = await fetch(`${location.protocol}//api.${location.host}/1/log`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded"
             },
             body: new URLSearchParams({
-                "content": pasteArea.value
+                "content": log
             })
         });
 


### PR DESCRIPTION
This PR limits the length and line number sent to the API by the frontend using the limits provided in the storage config.

This should fix #100 