### PR TITLE
Preserve whitespace in no-wrap mode

### DIFF
--- a/web/public/css/mclogs.css
+++ b/web/public/css/mclogs.css
@@ -286,7 +286,7 @@ body {
 }
 
 .log-row .no-wrap .level {
-    white-space: nowrap;
+    text-wrap: nowrap;
 }
 
 .log-notice {


### PR DESCRIPTION
`white-space: nowrap` sets `white-space-collapse` to `collapse` which removes important indentation.
It also sets `text-wrap` to `nowrap` which is what this PR does now.

Fixes #127, tested in Chrome and Firefox.
