### PR TITLE
Truncate the center of log files

### DIFF
--- a/core/config/filter.php
+++ b/core/config/filter.php
@@ -9,8 +9,8 @@ $config = [
      */
     'pre' => [
         '\\Filter\\Pre\\Trim',
-        '\\Filter\\Pre\\Length',
         '\\Filter\\Pre\\Lines',
+        '\\Filter\\Pre\\Length',
         '\\Filter\\Pre\\Ip',
         '\\Filter\\Pre\\Username',
         '\\Filter\\Pre\\AccessToken'

--- a/core/src/Filter/Pre/Lines.php
+++ b/core/src/Filter/Pre/Lines.php
@@ -15,6 +15,24 @@ class Lines implements PreFilterInterface {
     public static function Filter(string $data): string
     {
         $config = \Config::Get('storage');
-        return implode("\n", array_slice(explode("\n", $data), 0, $config["maxLines"]));
+        $limit = $config["maxLines"];
+
+        $lines = explode("\n", $data);
+        $count = count($lines);
+
+        if ($count <= $limit) {
+            return $data;
+        }
+
+        $removed = $count - $limit + 3;
+        $message = "Truncated " . $removed . " line" . ($removed > 1 ? "s" : "");
+
+        array_splice($lines, $limit / 2, $removed, [
+            str_repeat("=", strlen($message)),
+            $message,
+            str_repeat("=", strlen($message)),
+        ]);
+
+        return implode("\n", $lines);
     }
 }

--- a/web/public/js/mclogs.js
+++ b/web/public/js/mclogs.js
@@ -47,6 +47,40 @@ document.addEventListener('keydown', event => {
 })
 
 /**
+ * Limit the number of characters in a string by removing the end
+ * @param {string} string
+ * @param {number} limit
+ * @returns {string}
+ */
+function limitLength(string, limit = parseInt(pasteArea.dataset.maxLength)) {
+    return string.substring(0, limit);
+}
+
+/**
+ * Limit the number of lines in a string by truncating the middle
+ * @param {string} string
+ * @param {number} limit
+ * @returns {string}
+ */
+function limitLines(string, limit = parseInt(pasteArea.dataset.maxLines)) {
+    let lines = string.split('\n');
+    if (lines.length <= limit) {
+        return string;
+    }
+
+    let removed = lines.length - limit + 3;
+    let message = 'Truncated ' + removed + ' line' + (removed > 1 ? 's' : '');
+
+    lines.splice(limit / 2, removed,
+        "=".repeat(message.length),
+        message,
+        "=".repeat(message.length)
+    );
+
+    return lines.join('\n')
+}
+
+/**
  * Save the log to the API
  * @returns {Promise<void>}
  */
@@ -58,9 +92,9 @@ async function sendLog() {
     pasteSaveButtons.forEach(button => button.classList.add("btn-working"));
 
     try {
-        let log = pasteArea.value
-            .substring(0, parseInt(pasteArea.dataset.maxLength))
-            .split('\n').slice(0, parseInt(pasteArea.dataset.maxLines)).join('\n');
+        let log = pasteArea.value;
+        log = limitLines(log);
+        log = limitLength(log);
 
         const response = await fetch(`${location.protocol}//api.${location.host}/1/log`, {
             method: "POST",


### PR DESCRIPTION
This PR changes the length filter to truncate logs in the middle instead of truncating the end.

The beginning and end of a log file are usually the most interesting parts, as the beginning contains important version information used to detect the software and the end contains the error message of a crash.

The implementation was needed in both PHP and JS because this should work both for people using the API and the website (which already applied the old filter client side to prevent issues with upload limits).
Both implementations insert the same message at the center of the log:
```
===================
Truncated 593 lines
===================
```

I also changed the order of the length and lines filter to make sure that logs which reach both limits have their lines removed first.