### PR TITLE
PHP 8.4 compatability: Make parameter types explicitly nullable

### DIFF
--- a/core/src/Id.php
+++ b/core/src/Id.php
@@ -27,7 +27,7 @@ class Id
      *
      * @param string|null $fullId
      */
-    public function __construct(string $fullId = null)
+    public function __construct(?string $fullId = null)
     {
         if ($fullId === null) {
             $this->regenerate();

--- a/core/src/Log.php
+++ b/core/src/Log.php
@@ -47,7 +47,7 @@ class Log
      *
      * @param Id|null $id
      */
-    public function __construct(Id $id = null)
+    public function __construct(?Id $id = null)
     {
         if ($id) {
             $this->id = $id;


### PR DESCRIPTION
In PHP 8.4 implicitly marking parameters as nullable is deprecated. This PR explicitly marks the parameters as nullable by adding a `?` to the parameter types with a default value of null (`= null`).