### PR TITLE
Add null check for entry prefix in Printer

### DIFF
--- a/core/src/Printer/Printer.php
+++ b/core/src/Printer/Printer.php
@@ -63,7 +63,7 @@ class Printer extends ModifiableDefaultPrinter
             $return .= '<td class="line-number-container"><a href="/' . $this->id->get() . '#L' . $line->getNumber() . '" id="L' . $line->getNumber() . '" class="line-number">' . $line->getNumber() . '</a></td>';
             $return .= '<td><span class="level level-' . $entry->getLevel()->asString() . ((!$first) ? " multiline" : "") . '">';
             $lineString = $this->printLine($line);
-            if ($entry instanceof \Aternos\Codex\Minecraft\Log\Entry) {
+            if ($entry instanceof \Aternos\Codex\Minecraft\Log\Entry && $entry->getPrefix() !== null) {
                 $prefix = htmlentities($entry->getPrefix());
                 $lineString = str_replace($prefix, '<span class="level-prefix">' . $prefix . '</span>', $lineString);
             }


### PR DESCRIPTION
If the prefix of a log entry is null, it does not exist in `$lineString`. Then, we should not try to wrap it in: `<span class="level-prefix">` . This PR adds a null check for the entry prefix.
This PR also fixes the deprecation warning described in #153.