### PR TITLE
Generate limits in the UI based off config

### DIFF
--- a/api/frontend/main.php
+++ b/api/frontend/main.php
@@ -306,9 +306,10 @@ curl -X POST --data-urlencode 'content@path/to/latest.log' '<?=$urls['apiBaseUrl
                 <h3>Success <span class="content-type">application/json</span></h3>
                 <pre class="answer">
 {
-  "storageTime": 7776000,
-  "maxLength": 10485760,
-  "maxLines": 25000
+  "storageTime": <?php echo Config::Get('storage')['storageTime']; ?>,
+  "maxLength": <?php echo Config::Get('storage')['maxLength']; ?>,
+  "maxLines": <?php echo Config::Get('storage')['maxLines']; ?>
+
 }</pre>
                 <table class="endpoint-table">
                     <tr>

--- a/api/frontend/main.php
+++ b/api/frontend/main.php
@@ -1,6 +1,9 @@
 <?php
 $urls = Config::Get("urls");
 $legal = Config::Get('legal');
+$maxlines = Config::Get('storage')['maxLines'];
+$maxlength = Config::Get('storage')['maxLength'];
+$storagetime = Config::Get('storage')['storageTime'];
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -306,9 +309,9 @@ curl -X POST --data-urlencode 'content@path/to/latest.log' '<?=$urls['apiBaseUrl
                 <h3>Success <span class="content-type">application/json</span></h3>
                 <pre class="answer">
 {
-  "storageTime": <?php echo Config::Get('storage')['storageTime']; ?>,
-  "maxLength": <?php echo Config::Get('storage')['maxLength']; ?>,
-  "maxLines": <?php echo Config::Get('storage')['maxLines']; ?>
+  "storageTime": <?=$storagetime?>,
+  "maxLength": <?=$maxlength?>,
+  "maxLines": <?=$maxlines?>
 
 }</pre>
                 <table class="endpoint-table">


### PR DESCRIPTION
This PR updates the frontend API documentation page to dynamically display the storage limits (`storageTime`, `maxLength`, and `maxLines`) based on the server configuration instead of using hardcoded values. This ensures that the displayed limits always reflect the current configuration.