### PR TITLE
Set cookie expiration date

### DIFF
--- a/web/public/js/logview.js
+++ b/web/public/js/logview.js
@@ -125,6 +125,6 @@ if (wrapCheckbox) {
             document.querySelector(".log-row .row-inner").classList.add("no-wrap");
         }
         wrapCheckbox.scrollIntoView({behavior: "instant"});
-        document.cookie = "WRAP_LOG_LINES=" + wrapCheckbox.checked + ";path=/";
+        document.cookie = "WRAP_LOG_LINES=" + wrapCheckbox.checked + ";path=/;expires=" + new Date(new Date().getTime() + 365*24*60*60*1000).toUTCString();
     })
 }


### PR DESCRIPTION
We currently do not set an expiry date or max age for the WRAP_LOG_LINES cookie. That results in browsers deleting the cookie whenever the session ends (although many browsers restore an existing session when you reopen them).

This fixes https://github.com/aternosorg/mclogs/issues/174#issuecomment-3634420503