### PR TITLE
Automatically configure mongodb for docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 *.log
 .idea
-.vagrant
-config.php
 /vendor/
-mongo.php
+core/config/mongo.php

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -17,6 +17,7 @@ services:
         COPY mclogs.ini /usr/local/etc/php/conf.d/mclogs.ini
     volumes:
       - ../:/web/mclogs
+      - ./mongo.php:/web/mclogs/core/config/mongo.php
   mongo:
     image: mongo
     volumes:

--- a/docker/mongo.php
+++ b/docker/mongo.php
@@ -1,0 +1,4 @@
+<?php
+$config = [
+    "url" => "mongodb://mongo/"
+];


### PR DESCRIPTION
Currently the development setup with docker compose expects you to have a mongodb config already. This PR provides a config file that's automatically set up for the environment