### PR TITLE
horizontal scroll using smooth is too slow

### DIFF
--- a/web/public/css/mclogs.css
+++ b/web/public/css/mclogs.css
@@ -283,6 +283,7 @@ body {
 .log-row .no-wrap .log {
     max-width: unset;
     overflow-x: scroll;
+    scroll-behavior: auto;
 }
 
 .log-row .no-wrap .level {


### PR DESCRIPTION
mutliple people said that the horizontal scrolling was too slow, overrides the global smooth scrhooling specifically for the horizontal log container, giving native scrolling sideways.