### PR TITLE
fix: filter access/refresh tokens exposed by Feather Client

### DIFF
--- a/src/Filter/AccessTokenFilter.php
+++ b/src/Filter/AccessTokenFilter.php
@@ -14,6 +14,8 @@ class AccessTokenFilter extends RegexFilter
         return [
             new PatternWithReplacement('\(Session ID is token:[^:]+\:[^)]+\)', '(Session ID is token:****************:****************)'),
             new PatternWithReplacement('--accessToken [^ ]+', '--accessToken ****************:****************'),
+            new PatternWithReplacement('"authToken":"[^"]+"', '"authToken":"****************"'),
+            new PatternWithReplacement('"refreshToken":"[^"]+"', '"refreshToken":"****************"'),
         ];
     }
 }


### PR DESCRIPTION
Feather Client exposes tokens in the logs like this (redactions mine):

```
[13:12:52] [nioEventLoopGroup-3-1/DEBUG]: Rust Channel -> {"requestId":17,"callType":"callback","message":null,"success":{"accounts":[{"email":"","uuid":"[redacted]","name":"[redacted]","authToken":"[redacted]","expirationDate":"2026-03-23T17:11:36.289Z","refreshToken":"[redacted]"}]},"failure":null}
```